### PR TITLE
Suggested fixes for use as a WP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,24 @@ Require the autoloader at some point when `add_action` is available, like in `wp
 
 ### Install manually
 
-To install this manually without Compsoer, just download the [latest release ZIP](https://github.com/joshcanhelp/wp-rest-api-auth0/releases) and upload through the admin interface. Please note that this plugin will not update automatically; updates will need to be made by deleting and re-adding (make sure your site is in maintenance mode) or directly via an FTP client (not recommended).
+To install this manually without Composer, just download the [latest release ZIP](https://github.com/joshcanhelp/wp-rest-api-auth0/releases) and upload through the admin interface. Please note that this plugin will not update automatically; updates will need to be made by deleting and re-adding (make sure your site is in maintenance mode) or directly via an FTP client (not recommended).
 
 ## Testing with Docker
 
 You can get this running to test using Docker [using this Gist](https://gist.github.com/joshcanhelp/0e35b657ca03142e3d79595c28bb3ed7).
+
+### Troubleshooting
+
+If API requsts aren't working, Apache might not be passing authorization headers to PHP. Try adding this line (or similar methods) to `.htaccess`:
+
+```
+SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
+```
+
+Also, make sure your WP API endpoint doesn't follow this pattern, where `/index.php/` is required before `/wp-json/`:
+
+```
+Example:
+https://<your.site>/index.php/wp-json/
+```
+See [this solution](http://dejanjanosevic.info/remove-index-php-permalink-in-wordpress/) to help resolve this index.php issue.

--- a/src/wp-rest-api-auth0.php
+++ b/src/wp-rest-api-auth0.php
@@ -9,9 +9,6 @@ declare(strict_types=1);
 
 namespace JoshCanHelp\WordPress\RestApiAuth0;
 
-use Auth0\SDK\Helpers\Tokens\SymmetricVerifier;
-use Auth0\SDK\Helpers\Tokens\TokenVerifier;
-
 add_filter( 'determine_current_user', __NAMESPACE__ . '\\determine_current_user', 10, 1 );
 
 /**
@@ -49,10 +46,10 @@ function determine_current_user( $user ) {
 	// If we cannot validate the token for some reason, the request is processed without auth.
 
 	// Verify the incoming access token.
-	$token_verifier = new TokenVerifier(
+	$token_verifier = new \WP_Auth0_IdTokenVerifier(
 		'https://' . AUTH0_DOMAIN . '/',
 		AUTH0_API_AUDIENCE,
-		new SymmetricVerifier( AUTH0_API_SIGNING_SECRET )
+		new \WP_Auth0_SymmetricVerifier( AUTH0_API_SIGNING_SECRET )
 	);
 
 	try {


### PR DESCRIPTION
This is a suggested fix to resolve issue using this package as a WP plugin without Composer.

I believe **these are breaking changes** to the Composer version, which does install the Auth0 package in the same namespace as the WP Rest API Auth package, therefore this should be treated as a draft PR for consideration to reconcile with Composer and Plugin support (I'm not sure the best way to do both).

I changed this to rely on the class names provided by the "Login by Auth0" WP plugin:
- WP_Auth0_IdTokenVerifier
- WP_Auth0_SymmetricVerifier

as in the current version in main, the referenced classes (TokenVerifier, SymmetricVerifier) are missing.

This also includes some troubleshooting tips in the README to help others in general.