### PR TITLE
Stop exporting development files

### DIFF
--- a/,gitattributes
+++ b/,gitattributes
@@ -1,0 +1,4 @@
+/.github/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpcs.xml.dist export-ignore


### PR DESCRIPTION
For example GitHub ZIP, Composer package.

Test command: `git archive HEAD | tar --list`
(on POSIX systems)
