### PR TITLE
Fix namespace in defined()

### DIFF
--- a/src/wp-rest-api-auth0.php
+++ b/src/wp-rest-api-auth0.php
@@ -22,7 +22,7 @@ add_filter( 'determine_current_user', __NAMESPACE__ . '\\determine_current_user'
 function determine_current_user( $user ) {
 	global $wpdb;
 
-	$debug_mode = defined( '\AUTH0_API_DEBUG' ) && \AUTH0_API_DEBUG;
+	$debug_mode = defined( 'AUTH0_API_DEBUG' ) && \AUTH0_API_DEBUG;
 
 	// Only checked, not saved or output anywhere.
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput


### PR DESCRIPTION
`defined` always checks global namespace.

```php
<?php

namespace {
    define('MIN_SPEED', 0);
}

namespace Galaxy {
    const MAX_SPEED = 'lightspeed';

    var_dump(defined('MAX_SPEED')); // false
    var_dump(defined('Galaxy\\MAX_SPEED')); // true

    var_dump(defined('MIN_SPEED')); // true
    var_dump(defined('Galaxy\\MIN_SPEED')); // false
}
```
