### PR TITLE
Fix PHP warnings: undefined variable, unguarded JWT claims, unbounded get_users()

### DIFF
--- a/src/wp-rest-api-auth0.php
+++ b/src/wp-rest-api-auth0.php
@@ -49,7 +49,7 @@ function determine_current_user( $user ) {
 	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
-	$auth_header_parts = explode( ' ', $auth_header_raw ?? '' );
+	$auth_header_parts = explode( ' ', $auth_header ?? '' );
 	if ( 'bearer' !== strtolower( $auth_header_parts[0] ) || empty( $auth_header_parts[1] ) ) {
 		if ( $debug_mode ) {
 			error_log( 'WP REST API Auth0: No access token found in the request' );
@@ -82,7 +82,7 @@ function determine_current_user( $user ) {
 	}
 
 	// We don't have a user to associate this call to.
-	if ( ! $decoded_token['sub'] ) {
+	if ( empty( $decoded_token['sub'] ) ) {
 		if ( $debug_mode ) {
 			error_log( 'WP REST API Auth0: No sub claim found in the access token' );
 		}
@@ -94,15 +94,17 @@ function determine_current_user( $user ) {
 	}
 
 	// Look for a WordPress user with the incoming Auth0 ID.
-	if ( 'client-credentials' === $decoded_token['gty'] ) {
+	if ( 'client-credentials' === ( $decoded_token['gty'] ?? null ) ) {
 		$m2m_client_id = str_replace( '@clients', '', $decoded_token['sub'] );
 		$wp_user       = get_user_by( 'login', $m2m_client_id );
 	} else {
 		$wp_user = current(
 			get_users(
 				[
-					'meta_key'   => $wpdb->prefix . 'auth0_id',
-					'meta_value' => $decoded_token['sub'],
+					'meta_key'     => $wpdb->prefix . 'auth0_id',
+					'meta_value'   => $decoded_token['sub'],
+					'number'       => 1,
+					'count_total'  => false,
 				]
 			)
 		);
@@ -117,7 +119,7 @@ function determine_current_user( $user ) {
 	}
 
 	// Pull the scopes out of the access token and adjust the user accordingly.
-	if ( $decoded_token['scope'] ) {
+	if ( ! empty( $decoded_token['scope'] ) ) {
 		$access_token_scopes = explode( ' ', $decoded_token['scope'] );
 
 		if ( $debug_mode ) {


### PR DESCRIPTION
Fixes the three unambiguous bugs listed in #19. No design decisions involved, no behaviour change for valid requests.

### Changes

**1. Undefined variable `$auth_header_raw`**

`$auth_header_raw` was used on line 52 but never defined — t19he correct variable is `$auth_header`. This caused a PHP notice on every REST request carrying a Bearer token.

**2. Unguarded JWT claims (`sub`, `gty`, `scope`)**

Direct array access on `$decoded_token['sub']`, `$decoded_token['gty']`, and `$decoded_token['scope']` produced `PHP Warning: Undefined array key` whenever a valid token omitted any of these optional claims. Fixed with `empty()` and `?? null` guards.

**3. Unbounded `get_users()` query**

Added `'number' => 1` and `'count_total' => false` to bound the SQL query at the database level. While the `auth0_id` meta value should be unique in practice, the query was previously unbounded, which could be costly on large user tables.

### Testing

To verify the fixes, spin up your WP Docker environment and:

1. Make a REST request **without** an `Authorization` header (e.g. `GET /wp-json/wp/v2/posts`) — no PHP warnings should appear in the error log.
2. Make a request with a valid Bearer token whose JWT payload omits the `scope` or `gty` claims — no PHP warnings, request proceeds normally.
3. Make a request with a valid Bearer token for an existing user — authentication succeeds as before.